### PR TITLE
Remove stdout prints and allow stream selection

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -8,10 +8,6 @@ plugins:
   extractors:
   - name: "tap-saneedgedb"
     namespace: "tap_saneedgedb"
-    capabilities:
-      - state
-      - catalog
-      - discover
     pip_url: -e .
     config:
       start_date: '2010-01-01T00:00:00Z'

--- a/meltano.yml
+++ b/meltano.yml
@@ -8,6 +8,10 @@ plugins:
   extractors:
   - name: "tap-saneedgedb"
     namespace: "tap_saneedgedb"
+    capabilities:
+      - state
+      - catalog
+      - discover
     pip_url: -e .
     config:
       start_date: '2010-01-01T00:00:00Z'

--- a/tap_saneedgedb/rich_text_serializer.py
+++ b/tap_saneedgedb/rich_text_serializer.py
@@ -37,7 +37,6 @@ def convert_blocks_to_markdown(child_blocks: List[Any]) -> str:
                     else:
                         content.inline_link(block['href'], block['href'])
                 else:
-                    print("missing", block['type'], block)
                     raise ValueError("Unexpected block type")
             continue
         

--- a/tap_saneedgedb/streams.py
+++ b/tap_saneedgedb/streams.py
@@ -23,11 +23,10 @@ SCHEMAS_DIR = importlib_resources.files(__package__) / "schemas"
 class EdgeDbStream(Stream):
     primary_keys = ["id"]   
     is_sorted = True
-    selected_by_default = False
 
     def __init__(self, tap: Tap):
         super().__init__(tap)
-        print("Connecting to Edgedb instance", self.config.get('edgedb_host'))
+        self.logger.info("Connecting to Edgedb instance", self.config.get('edgedb_host'))
         self.client = edgedb.create_client(
             host = self.config.get('edgedb_host'),
             port = self.config.get('edgedb_port'),

--- a/tap_saneedgedb/streams.py
+++ b/tap_saneedgedb/streams.py
@@ -23,6 +23,7 @@ SCHEMAS_DIR = importlib_resources.files(__package__) / "schemas"
 class EdgeDbStream(Stream):
     primary_keys = ["id"]   
     is_sorted = True
+    selected_by_default = False
 
     def __init__(self, tap: Tap):
         super().__init__(tap)

--- a/tap_saneedgedb/tap.py
+++ b/tap_saneedgedb/tap.py
@@ -15,6 +15,10 @@ class TapSaneEdgedbTap(Tap):
 
     config_jsonschema = th.PropertiesList(
         th.Property(
+            "stream_name",
+            th.StringType,
+        ),
+        th.Property(
             "edgedb_host",
             th.StringType,
         ),
@@ -56,7 +60,14 @@ class TapSaneEdgedbTap(Tap):
         Returns:
             A list of discovered streams.
         """
-        print("connecting")
+        stream_by_name = {
+            "sane_users": streams.UserModelStream,
+            "sane_spaces": streams.SpaceModelStream,
+            "sane_space_nodes": streams.SpaceNodeModelStream,
+        }
+        if self.config.get("stream_name"):
+            return [stream_by_name[self.config["stream_name"]](self)]
+
         return [
             streams.UserModelStream(self),
             streams.SpaceModelStream(self),


### PR DESCRIPTION
Found a bug while trying to integrate the stream, as Meltano uses stdout to read input from the tap to extractor, the `print` usage was causing the extractor to crash.

Also added ability to select specific stream via config as Meltano select isn't working in my tests.